### PR TITLE
Fix growth time when breaking column plants or adding blocks to them

### DIFF
--- a/paper/src/main/java/com/untamedears/realisticbiomes/PlantLogicManager.java
+++ b/paper/src/main/java/com/untamedears/realisticbiomes/PlantLogicManager.java
@@ -37,60 +37,72 @@ public class PlantLogicManager {
 			plantManager.deletePlant(plant);
 			return;
 		}
+
+		handleColumnBlockDestruction(block);
+		handleFruitBlockDestruction(block);
+	}
+
+	public void handleColumnBlockDestruction(Block block) {
 		// column plants will always hold the plant object in the bottom most block, so
 		// we need
 		// to update that if we just broke one of the upper blocks of a column plant
-		if (columnBlocks != null && columnBlocks.contains(block.getType())) {
-			Block sourceColumn = VerticalGrower.getRelativeBlock(block ,RBUtils.getGrowthDirection(block.getType()).getOppositeFace());
-			Plant bottomColumnPlant = plantManager.getPlant(sourceColumn);
-			if (bottomColumnPlant != null) {
-				if (bottomColumnPlant.getGrowthConfig() == null
-						|| !(bottomColumnPlant.getGrowthConfig().getGrower() instanceof ColumnPlantGrower)) {
-					// Fallback behaviour
-					bottomColumnPlant.resetCreationTime();
-				} else {
-					ColumnPlantGrower grower = (ColumnPlantGrower) bottomColumnPlant.getGrowthConfig().getGrower();
-					
-					Block topColumn = VerticalGrower.getRelativeBlock(block ,RBUtils.getGrowthDirection(block.getType()));
-					int blocksBroken = Math.abs(topColumn.getY() - block.getY()) + 1;
-					long growthTime = bottomColumnPlant.getGrowthConfig().getPersistentGrowthTime(sourceColumn, true);
-					int stage = grower.getStage(bottomColumnPlant);
-					if (stage == grower.getMaxStage()) {
-						// If broken at max growth, set growth time offset from now based on amount of stages/blocks broken
-						int stagesLeft = stage - blocksBroken;
-						bottomColumnPlant.setCreationTime(System.currentTimeMillis() - (growthTime * stagesLeft) / stage);
-					} else {
-						// If not broken at max growth, increase creation time based on number of blocks broken
-						long create = bottomColumnPlant.getCreationTime();
-						bottomColumnPlant.setCreationTime(
-								(long) Math.min(System.currentTimeMillis(), create + (growthTime * Math.min(1.0D, (blocksBroken / (double) grower.getMaxStage())))));
-					}
-				}
-				updateGrowthTime(bottomColumnPlant, sourceColumn);
+
+		if (columnBlocks == null || !columnBlocks.contains(block.getType()))
+			return;
+
+		Block sourceColumn = VerticalGrower.getRelativeBlock(block ,RBUtils.getGrowthDirection(block.getType()).getOppositeFace());
+		Plant bottomColumnPlant = plantManager.getPlant(sourceColumn);
+		if (bottomColumnPlant == null)
+			return;
+
+		if (bottomColumnPlant.getGrowthConfig() == null
+				|| !(bottomColumnPlant.getGrowthConfig().getGrower() instanceof ColumnPlantGrower grower)) {
+			// Fallback behaviour
+			bottomColumnPlant.resetCreationTime();
+		} else {
+			Block topColumn = VerticalGrower.getRelativeBlock(block ,RBUtils.getGrowthDirection(block.getType()));
+			int blocksBroken = Math.abs(topColumn.getY() - block.getY()) + 1;
+			long growthTime = bottomColumnPlant.getGrowthConfig().getPersistentGrowthTime(sourceColumn, true);
+			int stage = grower.getStage(bottomColumnPlant);
+			if (stage == grower.getMaxStage()) {
+				// If broken at max growth, set growth time offset from now based on amount of stages/blocks broken
+				int stagesLeft = Math.max(stage - blocksBroken, 0);
+				bottomColumnPlant.setCreationTime(System.currentTimeMillis() - (growthTime * stagesLeft) / stage);
+			} else {
+				// If not broken at max growth, increase creation time based on number of blocks broken
+				long create = bottomColumnPlant.getCreationTime();
+				bottomColumnPlant.setCreationTime(
+						(long) Math.min(System.currentTimeMillis(), create + (growthTime * Math.min(1.0D, (blocksBroken / (double) grower.getMaxStage())))));
 			}
 		}
-		if (fruitBlocks != null && fruitBlocks.contains(block.getType())) {
-			for(BlockFace face : WorldUtils.PLANAR_SIDES) {
-				Block possibleStem = block.getRelative(face);
-				Plant stem = plantManager.getPlant(possibleStem);
-				if (stem == null) {
-					continue;
-				}
-				if (stem.getGrowthConfig() == null || !(stem.getGrowthConfig().getGrower() instanceof FruitGrower)) {
-					continue;
-				}
-				FruitGrower grower = (FruitGrower) stem.getGrowthConfig().getGrower();
-				if (grower.getFruitMaterial() != block.getType()) {
-					continue;
-				}
-				if (grower.getStage(stem) != grower.getMaxStage()) {
-					continue;
-				}
-				if (grower.getTurnedDirection(possibleStem) == face.getOppositeFace()) {
-					stem.resetCreationTime();
-					grower.setStage(stem, 0);
-					updateGrowthTime(stem, possibleStem);
-				}
+
+		updateGrowthTime(bottomColumnPlant, sourceColumn);
+	}
+
+	public void handleFruitBlockDestruction(Block block) {
+		if (fruitBlocks == null || !fruitBlocks.contains(block.getType()))
+			return;
+
+		for(BlockFace face : WorldUtils.PLANAR_SIDES) {
+			Block possibleStem = block.getRelative(face);
+			Plant stem = plantManager.getPlant(possibleStem);
+			if (stem == null) {
+				continue;
+			}
+			if (stem.getGrowthConfig() == null || !(stem.getGrowthConfig().getGrower() instanceof FruitGrower)) {
+				continue;
+			}
+			FruitGrower grower = (FruitGrower) stem.getGrowthConfig().getGrower();
+			if (grower.getFruitMaterial() != block.getType()) {
+				continue;
+			}
+			if (grower.getStage(stem) != grower.getMaxStage()) {
+				continue;
+			}
+			if (grower.getTurnedDirection(possibleStem) == face.getOppositeFace()) {
+				stem.resetCreationTime();
+				grower.setStage(stem, 0);
+				updateGrowthTime(stem, possibleStem);
 			}
 		}
 	}
@@ -131,15 +143,15 @@ public class PlantLogicManager {
 		if (growthConfig == null || !growthConfig.isPersistent()) {
 			return;
 		}
-		if (growthConfig.getGrower() instanceof VerticalGrower) {
-			BlockFace direction = ((VerticalGrower) growthConfig.getGrower()).getPrimaryGrowthDirection().getOppositeFace();
-			if (block.getRelative(direction).getType() == block.getType()) {
-				return;
-			}
-			if (block.getRelative(direction).getType() == RBUtils.getStemMaterial(block.getType())) {
-				return;
-			}
-			if (block.getRelative(direction).getType() == RBUtils.getTipMaterial(block.getType())) {
+		if (growthConfig.getGrower() instanceof VerticalGrower verticalGrower) {
+			BlockFace direction = verticalGrower.getPrimaryGrowthDirection().getOppositeFace();
+			Material blockMaterial = block.getType();
+			Material oppositeMaterial = block.getRelative(direction).getType();
+			if (oppositeMaterial == blockMaterial
+					|| oppositeMaterial == RBUtils.getStemMaterial(blockMaterial)
+					|| oppositeMaterial == RBUtils.getTipMaterial(blockMaterial))
+			{
+				handleColumnBlockAdded(block);
 				return;
 			}
 		}
@@ -150,6 +162,34 @@ public class PlantLogicManager {
 		}
 		plantManager.putPlant(plant);
 		updateGrowthTime(plant, block);
+	}
+
+	private void handleColumnBlockAdded(Block block) {
+		if (columnBlocks == null || !columnBlocks.contains(block.getType()))
+			return;
+
+		Block sourceColumn = VerticalGrower.getRelativeBlock(block ,RBUtils.getGrowthDirection(block.getType()).getOppositeFace());
+		Plant bottomColumnPlant = plantManager.getPlant(sourceColumn);
+		if (bottomColumnPlant == null)
+			return;
+
+		if (bottomColumnPlant.getGrowthConfig() == null
+				|| !(bottomColumnPlant.getGrowthConfig().getGrower() instanceof ColumnPlantGrower grower))
+		{
+			return;
+		}
+
+		int stage = grower.getStage(bottomColumnPlant);
+		if (stage == grower.getMaxStage())
+			return;
+
+		long create = bottomColumnPlant.getCreationTime();
+		long growthTime = bottomColumnPlant.getGrowthConfig().getPersistentGrowthTime(sourceColumn, true);
+		long newCreationTime = Math.min(System.currentTimeMillis(), create - growthTime / grower.getMaxStage());
+
+		bottomColumnPlant.setCreationTime(newCreationTime);
+
+		updateGrowthTime(bottomColumnPlant, sourceColumn);
 	}
 	
 	public Block remapColumnBlock(Block block, PlantGrowthConfig growthConfig, Material material) {

--- a/paper/src/main/java/com/untamedears/realisticbiomes/growth/BambooGrower.java
+++ b/paper/src/main/java/com/untamedears/realisticbiomes/growth/BambooGrower.java
@@ -33,7 +33,8 @@ public class BambooGrower extends ColumnPlantGrower {
 		if (!bottom.getLocation().equals(block.getLocation())) {
 			return -1;
 		}
-		return getActualHeight(block) - 1;
+		int stage = getActualHeight(block) - 1;
+		return Math.min(stage, getMaxStage());
 	}
 
 	private void handleProperLeafGrowth(Block block, Block highestBlock) {

--- a/paper/src/main/java/com/untamedears/realisticbiomes/growth/TipGrower.java
+++ b/paper/src/main/java/com/untamedears/realisticbiomes/growth/TipGrower.java
@@ -44,7 +44,8 @@ public class TipGrower extends ColumnPlantGrower{
 			}
 			break;
 		}
-		return count - 1;
+		int stage = count - 1;
+		return Math.min(stage, getMaxStage());
 	}
 
 	@Override

--- a/paper/src/main/java/com/untamedears/realisticbiomes/growth/VerticalGrower.java
+++ b/paper/src/main/java/com/untamedears/realisticbiomes/growth/VerticalGrower.java
@@ -67,7 +67,8 @@ public class VerticalGrower extends IArtificialGrower {
 		if (!bottom.getLocation().equals(block.getLocation())) {
 			return -1;
 		}
-		return getActualHeight(block) - 1;
+		int stage = getActualHeight(block) - 1;
+		return Math.min(stage, getMaxStage());
 	}
 
 	protected int getActualHeight(Block block) {


### PR DESCRIPTION
1. Limit ColumnPlantGrower.getStage to getMax. Fixes the bug that Diet_Cola found.
2. Adjust growth time when the new block is added to ColumnPlant. We didn't adjust the growth time if a new block was added to the ColumnPlant, so technically I can make my sugar cane fully grown but timer will show like 2 hours remained.