### PR TITLE
Fix for auto-replant and column plant bugs

### DIFF
--- a/paper/src/main/java/com/untamedears/realisticbiomes/growthconfig/PlantGrowthConfig.java
+++ b/paper/src/main/java/com/untamedears/realisticbiomes/growthconfig/PlantGrowthConfig.java
@@ -259,22 +259,33 @@ public class PlantGrowthConfig extends AbstractGrowthConfig {
 				sb.append(" is fully grown ");
 				return sb.toString();
 			}
-			long totalTime = getPersistentGrowthTime(block);
-			long passedTime = System.currentTimeMillis() - plant.getCreationTime();
-			long timeRemaining = Math.max(0, totalTime - passedTime);
-			if (timeRemaining >= INFINITE_TIME || totalTime == -1) {
-				sb.append(" will never grow here");
-			} else {
-				sb.append(" will grow to full size ");
-				if (timeRemaining <= 0) {
-					sb.append("now");
-				} else {
-					sb.append("in ");
-					sb.append(TextUtil.formatDuration(timeRemaining, TimeUnit.MILLISECONDS));
-				}
-			}
+			appendPlantProgress(block, plant, sb);
 		}
 		return sb.toString();
+	}
+
+	private void appendPlantProgress(Block block, Plant plant, StringBuilder sb) {
+		long totalTime = getPersistentGrowthTime(block);
+		long passedTime = System.currentTimeMillis() - plant.getCreationTime();
+		long timeRemaining = Math.max(0, totalTime - passedTime);
+
+		if (timeRemaining >= INFINITE_TIME || totalTime == -1) {
+			sb.append(" will never grow here");
+			return;
+		}
+
+		if (plant.getNextUpdate() == Long.MAX_VALUE) {
+			sb.append(" does not grow");
+			return;
+		}
+
+		sb.append(" will grow to full size ");
+		if (timeRemaining <= 0) {
+			sb.append("now");
+		} else {
+			sb.append("in ");
+			sb.append(TextUtil.formatDuration(timeRemaining, TimeUnit.MILLISECONDS));
+		}
 	}
 
 	/**

--- a/paper/src/main/java/com/untamedears/realisticbiomes/listener/PlayerListener.java
+++ b/paper/src/main/java/com/untamedears/realisticbiomes/listener/PlayerListener.java
@@ -7,6 +7,7 @@ import com.untamedears.realisticbiomes.RealisticBiomes;
 import com.untamedears.realisticbiomes.growthconfig.AnimalMateConfig;
 import com.untamedears.realisticbiomes.growthconfig.PlantGrowthConfig;
 import com.untamedears.realisticbiomes.model.Plant;
+import com.untamedears.realisticbiomes.utils.Constants;
 import com.untamedears.realisticbiomes.utils.RBUtils;
 import java.text.DecimalFormat;
 import org.bukkit.Bukkit;
@@ -49,7 +50,7 @@ public class PlayerListener implements Listener {
 		if (event.getItem() == null) {
 			return;
 		}
-		if (event.getItem().getType() != Material.STICK) {
+		if (event.getItem().getType() != Constants.Stick) {
 			return;
 		}
 		Block block = RBUtils.getRealPlantBlock(event.getClickedBlock());

--- a/paper/src/main/java/com/untamedears/realisticbiomes/replant/AutoReplantListener.java
+++ b/paper/src/main/java/com/untamedears/realisticbiomes/replant/AutoReplantListener.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
+
+import com.untamedears.realisticbiomes.utils.Constants;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -23,6 +23,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.PlayerHarvestBlockEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import vg.civcraft.mc.civmodcore.inventory.items.MaterialUtils;
@@ -68,7 +69,9 @@ public class AutoReplantListener implements Listener {
 
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	public void onRightClick(PlayerInteractEvent event) {
-		if (!rightClick) {
+		if (!rightClick
+				|| event.getHand() != EquipmentSlot.HAND) // Process only the main hand (no need to show 'no perms' twice)
+		{
 			return;
 		}
 
@@ -76,6 +79,11 @@ public class AutoReplantListener implements Listener {
 		if (block == null || event.getAction() != Action.RIGHT_CLICK_BLOCK) {
 			return;
 		}
+
+		ItemStack item = event.getItem();
+		if (item != null && item.getType() == Constants.Stick) // Do not auto-replant when the player just want to get growth info
+			return;
+
 		Player player = event.getPlayer();
 		if (!getToggleAutoReplant(player.getUniqueId())) {
 			return;

--- a/paper/src/main/java/com/untamedears/realisticbiomes/utils/Constants.java
+++ b/paper/src/main/java/com/untamedears/realisticbiomes/utils/Constants.java
@@ -1,0 +1,7 @@
+package com.untamedears.realisticbiomes.utils;
+
+import org.bukkit.Material;
+
+public class Constants {
+	public static Material Stick = Material.STICK;
+}


### PR DESCRIPTION
**Auto-replant bugs**:
1. When the player right clicks others crops then error message is shown twice
2. When the player with stick in hand right-clicks the grown plant then it auto-replants it instead of showing info

**Column plant bugs**:
Cap the twisting vine before 25 blocks (say, with a 5 tall roof)
Then remove the roof, right click vine and it shoots up
Break near bottom, right click again, shoots up again

If the plant is blocked by the block then the error message like this will be shown:
Twisting Vines does not grow

After the plant is unblocked the growth time is re-calculated