### PR TITLE
Mushroom spread fix

### DIFF
--- a/paper/src/main/java/com/untamedears/realisticbiomes/listener/PlantListener.java
+++ b/paper/src/main/java/com/untamedears/realisticbiomes/listener/PlantListener.java
@@ -152,7 +152,7 @@ public class PlantListener implements Listener {
 	 */
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onBlockSpread(BlockSpreadEvent event) {
-		handleGrowEvent(event, event.getSource(), event.getSource().getType());
+		handleGrowEvent(event, event.getSource(), event.getNewState().getType());
 //		Plant plant = plantManager.getPlant(event.getSource());
 //		PlantGrowthConfig growthConfig = getGrowthConfigFallback(event.getBlock());
 //		if (growthConfig != null) {


### PR DESCRIPTION
A bug: mushrooms still can use vanilla mechanic

randomTick() triggers on AIR blocks to spread mushrooms therefore we should check a new block state rather than the current.
